### PR TITLE
Updated the generated code to remove static fields

### DIFF
--- a/src/Abioc/AbiocContainer.WithContext.cs
+++ b/src/Abioc/AbiocContainer.WithContext.cs
@@ -19,7 +19,7 @@ namespace Abioc
         /// The compiler generated GetService method.
         /// </summary>
 #pragma warning disable SA1401 // Fields must be private
-        public readonly Func<Type, ConstructionContext<TExtra>, object> GeneratedGetService;
+        public readonly Func<Type, TExtra, object> GeneratedGetService;
 #pragma warning restore SA1401 // Fields must be private
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace Abioc
         public AbiocContainer(
             IReadOnlyDictionary<Type, Func<ConstructionContext<TExtra>, object>> singleMappings,
             IReadOnlyDictionary<Type, Func<ConstructionContext<TExtra>, object>[]> multiMappings,
-            Func<Type, ConstructionContext<TExtra>, object> generatedGetService)
+            Func<Type, TExtra, object> generatedGetService)
         {
             if (singleMappings == null)
                 throw new ArgumentNullException(nameof(singleMappings));

--- a/src/Abioc/AbiocContainer.WithContext.cs
+++ b/src/Abioc/AbiocContainer.WithContext.cs
@@ -19,7 +19,7 @@ namespace Abioc
         /// The compiler generated GetService method.
         /// </summary>
 #pragma warning disable SA1401 // Fields must be private
-        public readonly Func<Type, TExtra, object> GeneratedGetService;
+        public readonly IContainer<TExtra> GeneratedContainer;
 #pragma warning restore SA1401 // Fields must be private
 
         /// <summary>
@@ -29,22 +29,22 @@ namespace Abioc
         /// <param name="multiMappings">
         /// The compiled mapping from a type to potentially multiple create functions.
         /// </param>
-        /// <param name="generatedGetService">The compiler generated GetService method.</param>
+        /// <param name="generatedContainer">The runtime generated container.</param>
         public AbiocContainer(
             IReadOnlyDictionary<Type, Func<ConstructionContext<TExtra>, object>> singleMappings,
             IReadOnlyDictionary<Type, Func<ConstructionContext<TExtra>, object>[]> multiMappings,
-            Func<Type, TExtra, object> generatedGetService)
+            IContainer<TExtra> generatedContainer)
         {
             if (singleMappings == null)
                 throw new ArgumentNullException(nameof(singleMappings));
             if (multiMappings == null)
                 throw new ArgumentNullException(nameof(multiMappings));
-            if (generatedGetService == null)
-                throw new ArgumentNullException(nameof(generatedGetService));
+            if (generatedContainer == null)
+                throw new ArgumentNullException(nameof(generatedContainer));
 
             SingleMappings = singleMappings;
             MultiMappings = multiMappings;
-            GeneratedGetService = generatedGetService;
+            GeneratedContainer = generatedContainer;
         }
 
         /// <summary>

--- a/src/Abioc/AbiocContainer.cs
+++ b/src/Abioc/AbiocContainer.cs
@@ -16,7 +16,7 @@ namespace Abioc
         /// The compiler generated GetService method.
         /// </summary>
 #pragma warning disable SA1401 // Fields must be private
-        public readonly Func<Type, object> GeneratedGetService;
+        public readonly IContainer GeneratedContainer;
 #pragma warning restore SA1401 // Fields must be private
 
         /// <summary>
@@ -26,22 +26,22 @@ namespace Abioc
         /// <param name="multiMappings">
         /// The compiled mapping from a type to potentially multiple create functions.
         /// </param>
-        /// <param name="generatedGetService">The compiler generated GetService method.</param>
+        /// <param name="generatedContainer">The runtime generated container.</param>
         public AbiocContainer(
             IReadOnlyDictionary<Type, Func<object>> singleMappings,
             IReadOnlyDictionary<Type, Func<object>[]> multiMappings,
-            Func<Type, object> generatedGetService)
+            IContainer generatedContainer)
         {
             if (singleMappings == null)
                 throw new ArgumentNullException(nameof(singleMappings));
             if (multiMappings == null)
                 throw new ArgumentNullException(nameof(multiMappings));
-            if (generatedGetService == null)
-                throw new ArgumentNullException(nameof(generatedGetService));
+            if (generatedContainer == null)
+                throw new ArgumentNullException(nameof(generatedContainer));
 
             SingleMappings = singleMappings;
             MultiMappings = multiMappings;
-            GeneratedGetService = generatedGetService;
+            GeneratedContainer = generatedContainer;
         }
 
         /// <summary>

--- a/src/Abioc/Compilation/AbiocContainerExtensions.cs
+++ b/src/Abioc/Compilation/AbiocContainerExtensions.cs
@@ -18,23 +18,23 @@ namespace Abioc.Compilation
         /// <param name="multiMappings">
         /// The compiled mapping from a type to potentially multiple create functions.
         /// </param>
-        /// <param name="generatedGetService">The compiler generated GetService method.</param>
+        /// <param name="generatedContainer">The runtime generated container.</param>
         /// <returns>A new instance of the <see cref="AbiocContainer"/> class.</returns>
         public static AbiocContainer ToContainer(
             this IReadOnlyDictionary<Type, Func<object>[]> multiMappings,
-            Func<Type, object> generatedGetService)
+            IContainer generatedContainer)
         {
             if (multiMappings == null)
                 throw new ArgumentNullException(nameof(multiMappings));
-            if (generatedGetService == null)
-                throw new ArgumentNullException(nameof(generatedGetService));
+            if (generatedContainer == null)
+                throw new ArgumentNullException(nameof(generatedContainer));
 
             Dictionary<Type, Func<object>> singleMappings =
                 multiMappings
                     .Where(kvp => kvp.Value.Length == 1)
                     .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Single());
 
-            return new AbiocContainer(singleMappings, multiMappings, generatedGetService);
+            return new AbiocContainer(singleMappings, multiMappings, generatedContainer);
         }
 
         /// <summary>
@@ -46,23 +46,23 @@ namespace Abioc.Compilation
         /// <param name="multiMappings">
         /// The compiled mapping from a type to potentially multiple create functions.
         /// </param>
-        /// <param name="generatedGetService">The compiler generated GetService method.</param>
+        /// <param name="generatedContainer">The runtime generated container.</param>
         /// <returns>A new instance of the <see cref="AbiocContainer"/> class.</returns>
         public static AbiocContainer<TExtra> ToContainer<TExtra>(
             this IReadOnlyDictionary<Type, Func<ConstructionContext<TExtra>, object>[]> multiMappings,
-            Func<Type, TExtra, object> generatedGetService)
+            IContainer<TExtra> generatedContainer)
         {
             if (multiMappings == null)
                 throw new ArgumentNullException(nameof(multiMappings));
-            if (generatedGetService == null)
-                throw new ArgumentNullException(nameof(generatedGetService));
+            if (generatedContainer == null)
+                throw new ArgumentNullException(nameof(generatedContainer));
 
             Dictionary<Type, Func<ConstructionContext<TExtra>, object>> singleMappings =
                 multiMappings
                     .Where(kvp => kvp.Value.Length == 1)
                     .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Single());
 
-            return new AbiocContainer<TExtra>(singleMappings, multiMappings, generatedGetService);
+            return new AbiocContainer<TExtra>(singleMappings, multiMappings, generatedContainer);
         }
     }
 }

--- a/src/Abioc/Compilation/AbiocContainerExtensions.cs
+++ b/src/Abioc/Compilation/AbiocContainerExtensions.cs
@@ -50,7 +50,7 @@ namespace Abioc.Compilation
         /// <returns>A new instance of the <see cref="AbiocContainer"/> class.</returns>
         public static AbiocContainer<TExtra> ToContainer<TExtra>(
             this IReadOnlyDictionary<Type, Func<ConstructionContext<TExtra>, object>[]> multiMappings,
-            Func<Type, ConstructionContext<TExtra>, object> generatedGetService)
+            Func<Type, TExtra, object> generatedGetService)
         {
             if (multiMappings == null)
                 throw new ArgumentNullException(nameof(multiMappings));

--- a/src/Abioc/Compilation/CodeCompilation.cs
+++ b/src/Abioc/Compilation/CodeCompilation.cs
@@ -72,7 +72,7 @@ namespace Abioc.Compilation
                 let compositions = kvp.Value.Select(r => createMap[r.ImplementationType]).ToArray()
                 select (kvp.Key, compositions);
 
-            return iocMappings.ToDictionary(m => m.type, kvp => kvp.compositions).ToContainer(container.GetService);
+            return iocMappings.ToDictionary(m => m.type, kvp => kvp.compositions).ToContainer(container);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace Abioc.Compilation
                 let compositions = kvp.Value.Select(r => createMap[r.ImplementationType]).ToArray()
                 select (kvp.Key, compositions);
 
-            return iocMappings.ToDictionary(m => m.type, kvp => kvp.compositions).ToContainer(container.GetService);
+            return iocMappings.ToDictionary(m => m.type, kvp => kvp.compositions).ToContainer(container);
         }
 
         private static Func<object[], IContainer<TExtra>> CreateContainerFactory<TExtra>(Type type)

--- a/src/Abioc/Composition/CodeComposition.cs
+++ b/src/Abioc/Composition/CodeComposition.cs
@@ -115,7 +115,7 @@ namespace Abioc.Composition
             builder.Append(fieldsAndMethods);
 
             builder.Append(NewLine);
-            string fieldInitializationsMethod = GenerateFieldInitializationsMethod(code);
+            string fieldInitializationsMethod = GenerateConstructor(code);
             fieldInitializationsMethod = CodeGen.Indent(NewLine + fieldInitializationsMethod, 2);
             builder.Append(fieldInitializationsMethod);
 
@@ -150,21 +150,21 @@ namespace Abioc.Composition
             return fieldsAndMethods;
         }
 
-        private static string GenerateFieldInitializationsMethod(CodeCompositions code)
+        private static string GenerateConstructor(CodeCompositions code)
         {
             if (code == null)
                 throw new ArgumentNullException(nameof(code));
 
             var builder = new StringBuilder(1024);
             builder.AppendFormat(
-                "public void InitializeFields(" +
-                "{0}    System.Collections.Generic.IReadOnlyList<object> values){0}{{",
+                "public Container(" +
+                "{0}    object[] fieldValues){0}{{",
                 NewLine);
 
             for (int index = 0; index < code.FieldInitializations.Count; index++)
             {
                 (string snippet, object value) = code.FieldInitializations[index];
-                builder.Append($"{NewLine}    {snippet}values[{index}];");
+                builder.Append($"{NewLine}    {snippet}fieldValues[{index}];");
             }
 
             builder.AppendFormat("{0}}}", NewLine);

--- a/src/Abioc/Composition/CodeComposition.cs
+++ b/src/Abioc/Composition/CodeComposition.cs
@@ -101,22 +101,23 @@ namespace Abioc.Composition
             if (code == null)
                 throw new ArgumentNullException(nameof(code));
 
+            string genericContainerParam = code.HasConstructionContext ? $"<{context.ExtraDataType}>" : string.Empty;
+
             var builder = new StringBuilder(10240);
             builder.AppendFormat(
-                "namespace Abioc.Generated{0}{{{0}    public static class Construction{0}    {{",
-                NewLine);
+                "namespace Abioc.Generated{0}{{{0}    internal class Container : " +
+                "Abioc.IContainerInitialization{1}, Abioc.IContainer{1}{0}    {{",
+                NewLine,
+                genericContainerParam);
 
             string fieldsAndMethods = GenerateFieldsAndMethods(code);
             fieldsAndMethods = CodeGen.Indent(NewLine + fieldsAndMethods, 2);
             builder.Append(fieldsAndMethods);
 
-            if (code.FieldInitializations.Any())
-            {
-                builder.Append(NewLine);
-                string fieldInitializationsMethod = GenerateFieldInitializationsMethod(code);
-                fieldInitializationsMethod = CodeGen.Indent(NewLine + fieldInitializationsMethod, 2);
-                builder.Append(fieldInitializationsMethod);
-            }
+            builder.Append(NewLine);
+            string fieldInitializationsMethod = GenerateFieldInitializationsMethod(code);
+            fieldInitializationsMethod = CodeGen.Indent(NewLine + fieldInitializationsMethod, 2);
+            builder.Append(fieldInitializationsMethod);
 
             builder.Append(NewLine);
             string composeMapMethod = GenerateComposeMapMethod(code);
@@ -156,7 +157,7 @@ namespace Abioc.Composition
 
             var builder = new StringBuilder(1024);
             builder.AppendFormat(
-                "private static void InitializeFields(" +
+                "public void InitializeFields(" +
                 "{0}    System.Collections.Generic.IReadOnlyList<object> values){0}{{",
                 NewLine);
 
@@ -181,7 +182,7 @@ namespace Abioc.Composition
 
             var builder = new StringBuilder(1024);
             builder.AppendFormat(
-                "private static {0} GetCreateMap(){1}{{{1}    return new {0}{1}    {{",
+                "public {0} GetCreateMap(){1}{{{1}    return new {0}{1}    {{",
                 composeMapType,
                 NewLine);
 
@@ -204,15 +205,21 @@ namespace Abioc.Composition
                 throw new ArgumentNullException(nameof(code));
 
             string parameter = code.HasConstructionContext
-                ? $",{NewLine}    {code.ConstructionContext} context"
+                ? $",{NewLine}    {context.ExtraDataType} extraData"
+                : string.Empty;
+
+            string contextVariable = code.HasConstructionContext
+                ? $"{NewLine}    var context = new {code.ConstructionContext}(typeof(object), typeof(object), " +
+                  $"typeof(object), extraData);"
                 : string.Empty;
 
             var builder = new StringBuilder(1024);
             builder.AppendFormat(
-                "private static object GetService({0}    System.Type serviceType{1}){0}{{{0}    " +
+                "public object GetService({0}    System.Type serviceType{1}){0}{{{2}{0}    " +
                 "switch (serviceType.GetHashCode()){0}    {{",
                 NewLine,
-                parameter);
+                parameter,
+                contextVariable);
 
             IEnumerable<(Type key, IComposition composition)> singleIocMappings =
                 from kvp in code.Registrations
@@ -237,20 +244,6 @@ namespace Abioc.Composition
             }
 
             builder.AppendFormat("{0}    }}{0}{0}    return null;{0}}}", NewLine);
-
-            if (code.HasConstructionContext)
-            {
-                builder.AppendFormat(
-                    "{0}{0}private static System.Func<System.Type, {1}, object> GetGetServiceMethod(){0}{{{0}    return GetService;{0}}}",
-                    NewLine,
-                    code.ConstructionContext);
-            }
-            else
-            {
-                builder.AppendFormat(
-                    "{0}{0}private static System.Func<System.Type, object> GetGetServiceMethod(){0}{{{0}    return GetService;{0}}}",
-                    NewLine);
-            }
 
             return builder.ToString();
         }

--- a/src/Abioc/Composition/CodeGen.cs
+++ b/src/Abioc/Composition/CodeGen.cs
@@ -6,7 +6,6 @@ namespace Abioc.Composition
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Helper method for code generation.

--- a/src/Abioc/Composition/CompositionContext.cs
+++ b/src/Abioc/Composition/CompositionContext.cs
@@ -15,9 +15,11 @@ namespace Abioc.Composition
         /// <summary>
         /// Initializes a new instance of the <see cref="CompositionContext"/> class.
         /// </summary>
+        /// <param name="extraDataType">The type of the <see cref="ConstructionContext{T}.Extra"/> data.</param>
         /// <param name="constructionContext">The type of the <see cref="ConstructionContext{T}"/>.</param>
-        public CompositionContext(string constructionContext = null)
+        public CompositionContext(string extraDataType = null, string constructionContext = null)
         {
+            ExtraDataType = extraDataType;
             ConstructionContext = constructionContext ?? string.Empty;
         }
 
@@ -25,6 +27,11 @@ namespace Abioc.Composition
         /// Gets the context.
         /// </summary>
         public Dictionary<Type, IComposition> Compositions { get; } = new Dictionary<Type, IComposition>(32);
+
+        /// <summary>
+        /// Gets the type of the <see cref="ConstructionContext{T}.Extra"/> data.
+        /// </summary>
+        public string ExtraDataType { get; }
 
         /// <summary>
         /// Gets the type of the <see cref="ConstructionContext{T}"/>.

--- a/src/Abioc/Composition/Compositions/ConstructorComposition.cs
+++ b/src/Abioc/Composition/Compositions/ConstructorComposition.cs
@@ -86,7 +86,7 @@ namespace Abioc.Composition.Compositions
                 : string.Empty;
 
             string methodName = GetComposeMethodName(context, simpleName);
-            string signature = $"private static {Type.ToCompileName()} {methodName}({parameter})";
+            string signature = $"private {Type.ToCompileName()} {methodName}({parameter})";
 
             string instanceExpression = GetInstanceExpression(context, simpleName);
             instanceExpression = CodeGen.Indent(instanceExpression);

--- a/src/Abioc/Composition/Compositions/FactoryComposition.cs
+++ b/src/Abioc/Composition/Compositions/FactoryComposition.cs
@@ -77,12 +77,12 @@ namespace Abioc.Composition.Compositions
             string methodSignature =
                 requiresConstructionContext
                     ? string.Format(
-                        @"private static {0} {1}(
+                        @"private {0} {1}(
     {2} context)",
                         factoredType,
                         composeMethodName,
                         ConstructionContextType.ToCompileName())
-                    : $"private static {factoredType} {composeMethodName}()";
+                    : $"private {factoredType} {composeMethodName}()";
 
             string factoryCall =
                 requiresConstructionContext
@@ -158,7 +158,7 @@ namespace Abioc.Composition.Compositions
                     ? $"System.Func<{ConstructionContextType.ToCompileName()}, object>"
                     : $"System.Func<object>";
 
-            string field = $"private static {fieldType} {fieldName};";
+            string field = $"private {fieldType} {fieldName};";
             return new[] { field };
         }
 

--- a/src/Abioc/Composition/Compositions/InjectedSingletonComposition.cs
+++ b/src/Abioc/Composition/Compositions/InjectedSingletonComposition.cs
@@ -57,12 +57,12 @@ namespace Abioc.Composition.Compositions
             string method =
                 Type.GetTypeInfo().IsValueType
                     ? string.Format(
-                        "private static object {0}(){1}{{{1}    return (object){2};{1}}}",
+                        "private object {0}(){1}{{{1}    return (object){2};{1}}}",
                         methodName,
                         Environment.NewLine,
                         instanceExpression)
                     : string.Format(
-                        "private static {0} {1}(){2}{{{2}    return {3};{2}}}",
+                        "private {0} {1}(){2}{{{2}    return {3};{2}}}",
                         Type.ToCompileName(),
                         methodName,
                         Environment.NewLine,
@@ -103,7 +103,7 @@ namespace Abioc.Composition.Compositions
             string fieldName = GetInjectedFieldName();
             string fieldType = Type.ToCompileName();
 
-            string field = $"private static {fieldType} {fieldName};";
+            string field = $"private {fieldType} {fieldName};";
             return new[] { field };
         }
 

--- a/src/Abioc/Composition/Compositions/TypedFactoryComposition.cs
+++ b/src/Abioc/Composition/Compositions/TypedFactoryComposition.cs
@@ -106,7 +106,7 @@ namespace Abioc.Composition.Compositions
                     ? $"System.Func<{ConstructionContextType.ToCompileName()}, {returnType}>"
                     : $"System.Func<{returnType}>";
 
-            string field = $"private static {fieldType} {fieldName};";
+            string field = $"private {fieldType} {fieldName};";
             return new[] { field };
         }
 

--- a/src/Abioc/Composition/RegistrationComposition.cs
+++ b/src/Abioc/Composition/RegistrationComposition.cs
@@ -30,7 +30,9 @@ namespace Abioc.Composition
             if (setup == null)
                 throw new ArgumentNullException(nameof(setup));
 
-            return setup.Registrations.Compose(typeof(ConstructionContext<TExtra>).ToCompileName());
+            return setup.Registrations.Compose(
+                typeof(TExtra).ToCompileName(),
+                typeof(ConstructionContext<TExtra>).ToCompileName());
         }
 
         /// <summary>
@@ -49,12 +51,13 @@ namespace Abioc.Composition
 
         private static CompositionContext Compose(
             this IReadOnlyDictionary<Type, List<IRegistration>> registrations,
+            string extraDataType = null,
             string constructionContext = null)
         {
             if (registrations == null)
                 throw new ArgumentNullException(nameof(registrations));
 
-            var context = new CompositionContext(constructionContext);
+            var context = new CompositionContext(extraDataType, constructionContext);
 
             ProcessRegistrations(registrations, context);
 

--- a/src/Abioc/Composition/RegistrationComposition.cs
+++ b/src/Abioc/Composition/RegistrationComposition.cs
@@ -4,10 +4,8 @@
 namespace Abioc.Composition
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using Abioc.Registration;
 
     /// <summary>

--- a/src/Abioc/IContainer.WithContext.cs
+++ b/src/Abioc/IContainer.WithContext.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc
+{
+    using System;
+
+    /// <summary>
+    /// The interface implemented by the generated class for the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TExtra">
+    /// The type of the <see cref="ConstructionContext{TExtra}.Extra"/> construction context information.
+    /// </typeparam>
+    public interface IContainer<in TExtra>
+    {
+        /// <summary>
+        /// Gets the service of type <paramref name="serviceType"/>.
+        /// </summary>
+        /// <param name="serviceType">The type of the service to get.</param>
+        /// <param name="extraData">The custom extra data used during construction.</param>
+        /// <returns>The service of type <paramref name="serviceType"/>.</returns>
+        object GetService(Type serviceType, TExtra extraData);
+    }
+}

--- a/src/Abioc/IContainer.cs
+++ b/src/Abioc/IContainer.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc
+{
+    using System;
+
+    /// <summary>
+    /// The interface implemented by the generated class for the dependency injection container.
+    /// </summary>
+    public interface IContainer
+    {
+        /// <summary>
+        /// Gets the service of type <paramref name="serviceType"/>.
+        /// </summary>
+        /// <param name="serviceType">The type of the service to get.</param>
+        /// <returns>The service of type <paramref name="serviceType"/>.</returns>
+        object GetService(Type serviceType);
+    }
+}

--- a/src/Abioc/IContainerInitialization.WithContext.cs
+++ b/src/Abioc/IContainerInitialization.WithContext.cs
@@ -12,14 +12,8 @@ namespace Abioc
     /// <typeparam name="TExtra">
     /// The type of the <see cref="ConstructionContext{TExtra}.Extra"/> construction context information.
     /// </typeparam>
-    public interface IContainerInitialization<TExtra>
+    public interface IContainerInitialization<TExtra> : IContainer<TExtra>
     {
-        /// <summary>
-        /// Initializes all the fields of the container.
-        /// </summary>
-        /// <param name="values">The initialization values.</param>
-        void InitializeFields(IReadOnlyList<object> values);
-
         /// <summary>
         /// Returns the dictionary of types to factory functions.
         /// </summary>

--- a/src/Abioc/IContainerInitialization.WithContext.cs
+++ b/src/Abioc/IContainerInitialization.WithContext.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The initialization interface implemented by the generated class for the dependency injection container.
+    /// </summary>
+    /// <typeparam name="TExtra">
+    /// The type of the <see cref="ConstructionContext{TExtra}.Extra"/> construction context information.
+    /// </typeparam>
+    public interface IContainerInitialization<TExtra>
+    {
+        /// <summary>
+        /// Initializes all the fields of the container.
+        /// </summary>
+        /// <param name="values">The initialization values.</param>
+        void InitializeFields(IReadOnlyList<object> values);
+
+        /// <summary>
+        /// Returns the dictionary of types to factory functions.
+        /// </summary>
+        /// <returns>The dictionary of types to factory functions.</returns>
+        Dictionary<Type, Func<ConstructionContext<TExtra>, object>> GetCreateMap();
+    }
+}

--- a/src/Abioc/IContainerInitialization.cs
+++ b/src/Abioc/IContainerInitialization.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The initialization interface implemented by the generated class for the dependency injection container.
+    /// </summary>
+    public interface IContainerInitialization
+    {
+        /// <summary>
+        /// Initializes all the fields of the container.
+        /// </summary>
+        /// <param name="values">The initialization values.</param>
+        void InitializeFields(IReadOnlyList<object> values);
+
+        /// <summary>
+        /// Returns the dictionary of types to factory functions.
+        /// </summary>
+        /// <returns>The dictionary of types to factory functions.</returns>
+        Dictionary<Type, Func<object>> GetCreateMap();
+    }
+}

--- a/src/Abioc/IContainerInitialization.cs
+++ b/src/Abioc/IContainerInitialization.cs
@@ -9,14 +9,8 @@ namespace Abioc
     /// <summary>
     /// The initialization interface implemented by the generated class for the dependency injection container.
     /// </summary>
-    public interface IContainerInitialization
+    public interface IContainerInitialization : IContainer
     {
-        /// <summary>
-        /// Initializes all the fields of the container.
-        /// </summary>
-        /// <param name="values">The initialization values.</param>
-        void InitializeFields(IReadOnlyList<object> values);
-
         /// <summary>
         /// Returns the dictionary of types to factory functions.
         /// </summary>

--- a/src/Abioc/Registration/RegistrationBase.cs
+++ b/src/Abioc/Registration/RegistrationBase.cs
@@ -6,8 +6,6 @@ namespace Abioc.Registration
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// A base class that provides a default implementation of a <see cref="IRegistration"/>.

--- a/test/Abioc.Tests/GeneratedGetServiceTests.cs
+++ b/test/Abioc.Tests/GeneratedGetServiceTests.cs
@@ -40,12 +40,12 @@ namespace Abioc
 
         protected override TService GetService<TService>()
         {
-            return (TService)_container.GeneratedGetService(typeof(TService), 1);
+            return (TService)_container.GeneratedContainer.GetService(typeof(TService), 1);
         }
 
         protected override IEnumerable<TService> GetServices<TService>()
         {
-            object service = _container.GeneratedGetService(typeof(TService), 1);
+            object service = _container.GeneratedContainer.GetService(typeof(TService), 1);
             if (service != null)
             {
                 yield return (TService)service;
@@ -78,12 +78,12 @@ namespace Abioc
 
         protected override TService GetService<TService>()
         {
-            return (TService)_container.GeneratedGetService(typeof(TService));
+            return (TService)_container.GeneratedContainer.GetService(typeof(TService));
         }
 
         protected override IEnumerable<TService> GetServices<TService>()
         {
-            object service = _container.GeneratedGetService(typeof(TService));
+            object service = _container.GeneratedContainer.GetService(typeof(TService));
             if (service != null)
             {
                 yield return (TService)service;

--- a/test/Abioc.Tests/GeneratedGetServiceTests.cs
+++ b/test/Abioc.Tests/GeneratedGetServiceTests.cs
@@ -40,12 +40,12 @@ namespace Abioc
 
         protected override TService GetService<TService>()
         {
-            return (TService)_container.GeneratedGetService(typeof(TService), new ConstructionContext<int>());
+            return (TService)_container.GeneratedGetService(typeof(TService), 1);
         }
 
         protected override IEnumerable<TService> GetServices<TService>()
         {
-            object service = _container.GeneratedGetService(typeof(TService), new ConstructionContext<int>());
+            object service = _container.GeneratedGetService(typeof(TService), 1);
             if (service != null)
             {
                 yield return (TService)service;


### PR DESCRIPTION
The generated code is currently static methods and static fields. This makes caching the generated assembly unstable, (as there's a race condition to set the static fields).

By generating a class this is instantiated, the fields can be changed to instance fields rather than static fields, and can be initialised on a per instance basis.

Closes #10 (as it negates it).