### PR TITLE
Allow a class to have a dependency on IEnumerable

### DIFF
--- a/src/Abioc/Compilation/CodeCompilation.cs
+++ b/src/Abioc/Compilation/CodeCompilation.cs
@@ -159,9 +159,11 @@ namespace Abioc.Compilation
             if (srcAssembly == null)
                 throw new ArgumentNullException(nameof(srcAssembly));
 
-            string tempFileName = Path.GetTempFileName();
-            File.WriteAllText(tempFileName, code, Encoding.UTF8);
-            SyntaxTree tree = SyntaxFactory.ParseSyntaxTree(code, path: tempFileName, encoding: Encoding.UTF8);
+            // Need to review the code gen and file saving later.
+            ////string tempFileName = Path.GetTempFileName();
+            ////File.WriteAllText(tempFileName, code, Encoding.UTF8);
+            ////SyntaxTree tree = SyntaxFactory.ParseSyntaxTree(code, path: tempFileName, encoding: Encoding.UTF8);
+            SyntaxTree tree = SyntaxFactory.ParseSyntaxTree(code, encoding: Encoding.UTF8);
             ProcessDiagnostics(tree);
 
             var options = new CSharpCompilationOptions(

--- a/src/Abioc/Composition/CodeComposition.cs
+++ b/src/Abioc/Composition/CodeComposition.cs
@@ -110,7 +110,7 @@ namespace Abioc.Composition
 
             var builder = new StringBuilder(10240);
             builder.AppendFormat(
-                "namespace Abioc.Generated{0}{{{0}    internal class Container : " +
+                "namespace Abioc.Generated{0}{{{0}    using System.Linq;{0}{0}    internal class Container : " +
                 "Abioc.IContainerInitialization{1}, Abioc.IContainer{1}{0}    {{",
                 NewLine,
                 genericContainerParam);

--- a/src/Abioc/Composition/Compositions/CompositionBase.cs
+++ b/src/Abioc/Composition/Compositions/CompositionBase.cs
@@ -59,31 +59,5 @@ namespace Abioc.Composition.Compositions
 
         /// <inheritdoc />
         public abstract bool RequiresConstructionContext(CompositionContext context);
-
-        /// <summary>
-        /// Gets all the compositions for the specified <paramref name="types"/>.
-        /// </summary>
-        /// <param name="context">The <see cref="CompositionContext"/>.</param>
-        /// <param name="types">The types for which to retrieve the compositions.</param>
-        /// <returns>All the compositions for the specified <paramref name="types"/>.</returns>
-        protected static IEnumerable<IComposition> GetCompositions(CompositionContext context, IEnumerable<Type> types)
-        {
-            if (context == null)
-                throw new ArgumentNullException(nameof(context));
-            if (types == null)
-                throw new ArgumentNullException(nameof(types));
-
-            foreach (Type type in types)
-            {
-                if (context.Compositions.TryGetValue(type, out IComposition composition))
-                {
-                    yield return composition;
-                }
-                else
-                {
-                    throw new CompositionException($"There is no composition for the type: '{type}'.");
-                }
-            }
-        }
     }
 }

--- a/src/Abioc/Composition/Compositions/EnumerableParameterExpression.cs
+++ b/src/Abioc/Composition/Compositions/EnumerableParameterExpression.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc.Composition.Compositions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// The parameter expression that uses <see cref="IContainer.GetServices"/> to resolve a parameter.
+    /// </summary>
+    internal class EnumerableParameterExpression : IParameterExpression
+    {
+        private readonly bool _requiresConstructionContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumerableParameterExpression"/> class.
+        /// </summary>
+        /// <param name="enumerableType">The type of the <see cref="IEnumerable{T}"/> parameter.</param>
+        /// <param name="requiresConstructionContext">
+        /// The value indicating whether the <see cref="IParameterExpression"/> requires a
+        /// <see cref="ConstructionContext{T}"/>.
+        /// </param>
+        public EnumerableParameterExpression(Type enumerableType, bool requiresConstructionContext)
+        {
+            if (enumerableType == null)
+                throw new ArgumentNullException(nameof(enumerableType));
+
+            EnumerableType = enumerableType;
+            _requiresConstructionContext = requiresConstructionContext;
+        }
+
+        /// <summary>
+        /// Gets the type of the <see cref="IEnumerable{T}"/> <see cref="IParameterExpression"/>.
+        /// </summary>
+        public Type EnumerableType { get; }
+
+        /// <inheritdoc />
+        public string GetInstanceExpression(CompositionContext context, bool simpleName)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            string enumerableTypeName = EnumerableType.ToCompileName();
+            string serviceTypeparameter = $"typeof({enumerableTypeName})";
+            string contextParameter = _requiresConstructionContext ? ", context.Extra" : string.Empty;
+
+            string expression = $"GetServices({serviceTypeparameter}{contextParameter}).Cast<{enumerableTypeName}>()";
+            return expression;
+        }
+
+        /// <inheritdoc />
+        public bool RequiresConstructionContext(CompositionContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            return _requiresConstructionContext;
+        }
+    }
+}

--- a/src/Abioc/Composition/Compositions/IParameterExpression.cs
+++ b/src/Abioc/Composition/Compositions/IParameterExpression.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc.Composition.Compositions
+{
+    using System;
+
+    /// <summary>
+    /// Defines the interface a parameter expression must implement.
+    /// </summary>
+    internal interface IParameterExpression
+    {
+        /// <summary>
+        /// Gets the code for the expression (e.g. method call or instance field) to retrieve an instance of the
+        /// <see cref="Type"/>.
+        /// </summary>
+        /// <param name="context">The whole composition context.</param>
+        /// <param name="simpleName">
+        /// <p>
+        /// If <see langword="true"/> simple method names should be produced; otherwise produce complex method names.
+        /// </p>
+        /// <p>
+        /// A simple method may potentially produce conflicts; though it will produce more readable code.
+        /// </p>
+        /// </param>
+        /// <returns>
+        /// The code for the expression (e.g. method call or instance field) to retrieve an instance of the
+        /// <see cref="Type"/>.
+        /// </returns>
+        string GetInstanceExpression(CompositionContext context, bool simpleName);
+
+        /// <summary>
+        /// Returns the value indicating whether the <see cref="IParameterExpression"/> requires a
+        /// <see cref="ConstructionContext{T}"/>.
+        /// </summary>
+        /// <param name="context">The whole composition context.</param>
+        /// <returns>
+        /// The value indicating whether the <see cref="IParameterExpression"/> requires a
+        /// <see cref="ConstructionContext{T}"/>.
+        /// </returns>
+        bool RequiresConstructionContext(CompositionContext context);
+    }
+}

--- a/src/Abioc/Composition/Compositions/SimpleParameterExpression.cs
+++ b/src/Abioc/Composition/Compositions/SimpleParameterExpression.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc.Composition.Compositions
+{
+    using System;
+
+    /// <summary>
+    /// The default parameter expression that defaults to the expression of a <see cref="IComposition"/>.
+    /// </summary>
+    internal class SimpleParameterExpression : IParameterExpression
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleParameterExpression"/> class.
+        /// </summary>
+        /// <param name="composition">The <see cref="Composition"/> used to satisfy the parameter expression.</param>
+        public SimpleParameterExpression(IComposition composition)
+        {
+            if (composition == null)
+                throw new ArgumentNullException(nameof(composition));
+
+            Composition = composition;
+        }
+
+        /// <summary>
+        /// Gets the composition used to satisfy the parameter expression.
+        /// </summary>
+        public IComposition Composition { get; }
+
+        /// <inheritdoc />
+        public string GetInstanceExpression(CompositionContext context, bool simpleName)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            return Composition.GetInstanceExpression(context, simpleName);
+        }
+
+        /// <inheritdoc />
+        public bool RequiresConstructionContext(CompositionContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            return Composition.RequiresConstructionContext(context);
+        }
+    }
+}

--- a/test/Abioc.Tests/Abioc.Tests.csproj
+++ b/test/Abioc.Tests/Abioc.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="ConstructorErrorTests.cs" />
     <Compile Include="CreateObjectGraphTests.cs" />
     <Compile Include="DebuggerDisplayTests.cs" />
+    <Compile Include="EnumerableDependencyTests.cs" />
     <Compile Include="ExampleServices.cs" />
     <Compile Include="FactoryServicesTests.cs" />
     <Compile Include="Filter\NotDelegate.cs" />

--- a/test/Abioc.Tests/EnumerableDependencyTests.cs
+++ b/test/Abioc.Tests/EnumerableDependencyTests.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) 2017 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Abioc
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Abioc.EnumerableDependencyTests;
+    using Abioc.Registration;
+    using FluentAssertions;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    namespace EnumerableDependencyTests
+    {
+        public interface IMultipleDependency
+        {
+        }
+
+        public interface IZeroDependency
+        {
+        }
+
+        public interface ISingleDependency
+        {
+        }
+
+        public class MultipleDependency1 : IMultipleDependency
+        {
+        }
+
+        public class MultipleDependency2 : IMultipleDependency
+        {
+        }
+
+        public class MultipleDependency3 : IMultipleDependency
+        {
+        }
+
+        public class SingleDependency : ISingleDependency
+        {
+        }
+
+        public class DependentClass
+        {
+            public DependentClass(
+                IEnumerable<IMultipleDependency> multipleDependencies,
+                IEnumerable<IZeroDependency> zeroDependencies,
+                IEnumerable<ISingleDependency> singleDependencies)
+            {
+                MultipleDependencies = multipleDependencies?.ToArray() ??
+                                       throw new ArgumentNullException(nameof(multipleDependencies));
+                ZeroDependencies = zeroDependencies?.ToArray() ??
+                                   throw new ArgumentNullException(nameof(zeroDependencies));
+                SingleDependencies = singleDependencies?.ToArray() ??
+                                     throw new ArgumentNullException(nameof(singleDependencies));
+            }
+
+            public IMultipleDependency[] MultipleDependencies { get; }
+            public IZeroDependency[] ZeroDependencies { get; }
+            public ISingleDependency[] SingleDependencies { get; }
+
+        }
+    }
+
+    public abstract class EnumerableDependencyTestsBase
+    {
+        protected abstract TService GetService<TService>();
+
+        [Fact]
+        public void ItShouldResolveTheRegisteredMultipleDependencies()
+        {
+            // Act
+            DependentClass actual = GetService<DependentClass>();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.MultipleDependencies
+                .Should()
+                .NotBeNull()
+                .And.HaveCount(3)
+                .And.ContainSingle(d => d.GetType() == typeof(MultipleDependency1))
+                .And.ContainSingle(d => d.GetType() == typeof(MultipleDependency2))
+                .And.ContainSingle(d => d.GetType() == typeof(MultipleDependency3));
+        }
+
+        [Fact]
+        public void ItShouldProvideAnEmptyEnumerableWhereThereAreNoRegistrations()
+        {
+            // Act
+            DependentClass actual = GetService<DependentClass>();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.ZeroDependencies
+                .Should()
+                .NotBeNull()
+                .And.BeEmpty();
+        }
+
+        [Fact]
+        public void ItShouldProvideAnEnumerableForASingleDependency()
+        {
+            // Act
+            DependentClass actual = GetService<DependentClass>();
+
+            // Assert
+            actual.Should().NotBeNull();
+            actual.SingleDependencies
+                .Should()
+                .NotBeNull()
+                .And.HaveCount(1)
+                .And.ContainSingle(d => d.GetType() == typeof(SingleDependency));
+        }
+    }
+
+    public class WhenRegisteringAClassWithEnumerableDependenciesWithAContext : EnumerableDependencyTestsBase
+    {
+        private readonly AbiocContainer<int> _container;
+
+        public WhenRegisteringAClassWithEnumerableDependenciesWithAContext(ITestOutputHelper output)
+        {
+            _container =
+                new RegistrationSetup<int>()
+                    .Register<IMultipleDependency, MultipleDependency1>()
+                    .RegisterFactory<IMultipleDependency, MultipleDependency2>(c => new MultipleDependency2())
+                    .RegisterSingleton<IMultipleDependency, MultipleDependency3>(c => c.UseFactory(f => new MultipleDependency3()))
+                    .RegisterFactory(typeof(ISingleDependency), typeof(SingleDependency), f => new SingleDependency())
+                    .Register<DependentClass>()
+                    .Construct(GetType().GetTypeInfo().Assembly, out string code);
+
+            output.WriteLine(code);
+        }
+
+        protected override TService GetService<TService>() => _container.GetService<TService>(1);
+    }
+
+    public class WhenRegisteringAClassWithEnumerableDependenciesWithourAContext : EnumerableDependencyTestsBase
+    {
+        private readonly AbiocContainer _container;
+
+        public WhenRegisteringAClassWithEnumerableDependenciesWithourAContext(ITestOutputHelper output)
+        {
+            _container =
+                new RegistrationSetup()
+                    .Register<IMultipleDependency, MultipleDependency1>()
+                    .RegisterFactory<IMultipleDependency, MultipleDependency2>(() => new MultipleDependency2())
+                    .RegisterSingleton<IMultipleDependency, MultipleDependency3>(c => c.UseFactory(() => new MultipleDependency3()))
+                    .RegisterFactory(typeof(ISingleDependency), typeof(SingleDependency), () => new SingleDependency())
+                    .Register<DependentClass>()
+                    .Construct(GetType().GetTypeInfo().Assembly, out string code);
+
+            output.WriteLine(code);
+        }
+
+        protected override TService GetService<TService>() => _container.GetService<TService>();
+    }
+}

--- a/test/Abioc.Tests/MissingConstructorDependencyTests.cs
+++ b/test/Abioc.Tests/MissingConstructorDependencyTests.cs
@@ -47,8 +47,8 @@ namespace Abioc
         {
             // Arrange
             string expectedMessage =
-                "Failed to get the compositions for the parameters to the constructor of " +
-                $"'{typeof(DependantClass)}'. Is there a missing registration mapping?";
+                $"Failed to get the compositions for the parameter '{typeof(DependencyClass2)} dependency2' to the " +
+                $"constructor of '{typeof(DependantClass)}'. Is there a missing registration mapping?";
 
             // Act
             Action action = () => _setup.Compose().GenerateCode(_setup.Registrations);


### PR DESCRIPTION
It should inject the an enumerable if a dependent services requires it on the constructor for:

- [X] Multiple dependencies (where there are several registrations for the same interface)
- [X] Zero dependencies (where there are no registrations)
- [X] Single dependency (a single registration is still provided as an `IEnumerable<>`)