### PR TITLE
Updated to the latest StyleCop

### DIFF
--- a/RestorePackages.cmd
+++ b/RestorePackages.cmd
@@ -5,7 +5,7 @@
 @IF NOT EXIST %CACHED_NUGET% (
 	echo Downloading latest version of NuGet.exe...
 	IF NOT EXIST "%USERPROFILE%\.nuget" md "%USERPROFILE%\.nuget"
-	powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe' -OutFile %CACHED_NUGET:"='%"
+	powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile %CACHED_NUGET:"='%"
 )
 
 @echo %CACHED_NUGET% restore abioc.sln

--- a/src/Abioc/Abioc.csproj
+++ b/src/Abioc/Abioc.csproj
@@ -28,14 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
-  </ItemGroup>
-
-  <!--
-  Disable StyleCop as it breaks dotnet build compilation, and therefore breaks the travis CI build
-  -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'dontbother' ">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
No longer need to disable StyleCop as it now builds on Travis thanks to DotNetAnalyzers/StyleCopAnalyzers#2351.