### PR TITLE
Downgrade to setup-dotnet@v1.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1.0.2
       with:
         dotnet-version: ${{ matrix.dotnet }}
     - name: Test Coverage


### PR DESCRIPTION
This fixes actions/setup-dotnet#29 which was introduced by actions/setup-dotnet#12.